### PR TITLE
ci: switch npm publish from NPM_TOKEN to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -45,9 +49,7 @@ jobs:
           pnpm run build
       - run: |
           cd playwright
-          pnpm publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          pnpm publish --no-git-checks --provenance
 
   publish-metadata:
     needs: publish-npm


### PR DESCRIPTION
## 变更内容

- 添加 \`id-token: write\` 权限，允许 GitHub 签发 OIDC 令牌
- 移除 \`NODE_AUTH_TOKEN\` 环境变量（不再需要 NPM Token secret）
- 添加 \`--provenance\` 参数，发布时附带供应链来源证明

## 优势

- **无需维护 Token**：不再有 90 天过期问题
- **更安全**：每次发布使用 5 分钟有效的临时令牌
- **可验证**：\`--provenance\` 提供包的构建来源证明

## 后续操作

合并后需在 npmjs.com 配置 Trusted Publisher：
- Repository owner: \`OpenTestSolar\`
- Repository name: \`testtool-javascript-playwright\`
- Workflow filename: \`npm-publish.yml\`
- Environment: 留空

配置完成后可删除 GitHub Secrets 中的 \`NPM_TOKEN\`。